### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,19 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
 
 matrix:
   fast_finish: true
+  include:
+  - python: 3.7
+    dist: xenial
+    sudo: true
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install -r requirements_test.txt
+install: pip install tox-travis
 
 # command to run tests using coverage, e.g. python setup.py test
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Also, if we just want to know if action is permitted, just let's run:
     False
     
     >>> validation.error  # it's an actual exception
-    LogicException('Validation failed!',)
+    LogicException('Validation failed!')
 
 
 
@@ -155,7 +155,7 @@ make our own errors!
    False
    
    >>> result.error
-   LogicException('User is too young to watch this',)
+   LogicException('User is too young to watch this')
    
    >>> result.error_code == 'CANT_WATCH_MOVIE_TOO_YOUNG'
    True

--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Also, if we just want to know if action is permitted, just let's run:
     False
     
     >>> validation.error  # it's an actual exception
-    LogicException('Validation failed!')
+    LogicException('Validation failed!', error_code=None)
 
 
 
@@ -155,7 +155,7 @@ make our own errors!
    False
    
    >>> result.error
-   LogicException('User is too young to watch this')
+   LogicException('User is too young to watch this', error_code='CANT_WATCH_MOVIE_TOO_YOUNG')
    
    >>> result.error_code == 'CANT_WATCH_MOVIE_TOO_YOUNG'
    True

--- a/business_logic/exceptions.py
+++ b/business_logic/exceptions.py
@@ -36,6 +36,12 @@ class LogicException(Exception):
     def __hash__(self):
         return hash(str(self))
 
+    def __repr__(self):
+        cls_name = self.__class__.__name__
+        exc_args = ', '.join(repr(a) for a in self.args)
+        code = repr(self.error_code)
+        return u'{}({}, error_code={})'.format(cls_name, exc_args, code)
+
 
 class InvalidOperationException(LogicException):
     pass

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ setup(
         'business_logic',
     ],
     include_package_data=True,
-    install_requires=[],
+    install_requires=[
+        'six'
+    ],
     license="MIT",
     zip_safe=False,
     keywords='python-business-logic',

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/business_logic
 commands =
     coverage run --source business_logic -m unittest discover
-    python -m doctest -v README.rst
+    python -m doctest README.rst
 
 deps =
     -r{toxinidir}/requirements_test.txt


### PR DESCRIPTION
Removed 3.3 from Travis (Because of Travis problems to support it)
Fixed issue with Python3.7 tests because of changed default `repr()` for exceptions - https://bugs.python.org/issue30399

Additionally, added six as a dependency (it was used, but missing in `setup.py`)